### PR TITLE
Fix trans selection

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -7,22 +7,28 @@ __all__ = ['SaleConfiguration']
 
 
 class SaleConfiguration:
-    __name__ = "sale.configuration"
+    __name__ = 'sale.configuration'
 
-    payment_authorize_on = fields.Selection(
-        "get_authorize_options", "Payment Authorize On", required=True,
-    )
-    payment_capture_on = fields.Selection(
-        "get_capture_options", "Payment Capture On", required=True,
-    )
+    payment_authorize_on = fields.Selection([
+            ('manual', 'Manual'),
+            ('sale_confirm', 'Sale Confirm'),
+            ('sale_process', 'Sale Process'),
+            ], 'Payment Authorize On', required=True,
+        )
+    payment_capture_on = fields.Selection([
+            ('manual', 'Manual'),
+            ('sale_confirm', 'Sale Confirm'),
+            ('sale_process', 'Sale Process'),
+            ], 'Payment Capture On', required=True,
+        )
 
     @classmethod
     def __setup__(cls):
         super(SaleConfiguration, cls).__setup__()
 
         cls._error_messages.update({
-            "auth_before_capture":
-                "Payment authorization must happen before capture"
+            'auth_before_capture':
+                'Payment authorization must happen before capture'
         })
 
     @classmethod
@@ -35,28 +41,12 @@ class SaleConfiguration:
     def validate_payment_combination(self):
         if self.payment_authorize_on == 'sale_process' and \
                 self.payment_capture_on == 'sale_confirm':
-            self.raise_user_error("auth_before_capture")
+            self.raise_user_error('auth_before_capture')
 
     @staticmethod
     def default_payment_authorize_on():
-        return "sale_confirm"
+        return 'sale_confirm'
 
     @staticmethod
     def default_payment_capture_on():
-        return "sale_process"
-
-    @classmethod
-    def get_authorize_options(cls):
-        return [
-            ("manual", "Manual"),
-            ("sale_confirm", "Sale Confirm"),
-            ("sale_process", "Sale Process"),
-        ]
-
-    @classmethod
-    def get_capture_options(cls):
-        return [
-            ("manual", "Manual"),
-            ("sale_confirm", "Sale Confirm"),
-            ("sale_process", "Sale Process"),
-        ]
+        return 'sale_process'

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -22,7 +22,7 @@ msgid ""
 "Payments: %s"
 msgstr ""
 "Fehlbetrag in Zahlung:\n"
-"Zu autorisierterender Betrag: %\n"
+"Zu autorisierender Betrag: %s\n"
 "Verbleibender Betrag: %s\n"
 "Zahlungen: %s"
 
@@ -34,7 +34,7 @@ msgid ""
 "Payments: %s"
 msgstr ""
 "Fehlbetrag in Zahlung:\n"
-"Einzuziehender Betrag: %\n"
+"Einzuziehender Betrag: %s\n"
 "Verbleibender Betrag: %s\n"
 "Zahlungen: %s"
 
@@ -52,11 +52,11 @@ msgstr "Zahlung"
 
 msgctxt "field:sale.configuration,payment_authorize_on:"
 msgid "Payment Authorize On"
-msgstr "Zahlungsautorisierung bei"
+msgstr "Zahlungsautorisierung"
 
 msgctxt "field:sale.configuration,payment_capture_on:"
 msgid "Payment Capture On"
-msgstr "Zahlungseinzug bei"
+msgstr "Zahlungseinzug"
 
 msgctxt "field:sale.payment,amount:"
 msgid "Amount"
@@ -111,7 +111,7 @@ msgid "ID"
 msgstr "ID"
 
 msgctxt "field:sale.payment,method:"
-msgid "Payment Method"
+msgid "Method"
 msgstr "Zahlungsmethode"
 
 msgctxt "field:sale.payment,party:"
@@ -127,7 +127,7 @@ msgid "Payment Transactions"
 msgstr "Zahlungstransaktionen"
 
 msgctxt "field:sale.payment,provider:"
-msgid "Payment Provider"
+msgid "Provider"
 msgstr "Zahlungsprovider"
 
 msgctxt "field:sale.payment,rec_name:"
@@ -240,7 +240,7 @@ msgstr "Gateway Transaktionen"
 
 msgctxt "field:sale.sale,payment_authorize_on:"
 msgid "Payment Authorize On"
-msgstr "Zahlungsautorisierung bei"
+msgstr "Zahlungsautorisierung"
 
 msgctxt "field:sale.sale,payment_authorized:"
 msgid "Payment Authorized"
@@ -252,7 +252,7 @@ msgstr "Zahlung verbleibend"
 
 msgctxt "field:sale.sale,payment_capture_on:"
 msgid "Payment Captured On"
-msgstr "Zahlungseinzug bei"
+msgstr "Zahlungseinzug"
 
 msgctxt "field:sale.sale,payment_captured:"
 msgid "Payment Captured"
@@ -334,6 +334,30 @@ msgstr "Zahlung"
 msgctxt "model:sale.payment.add_view,name:"
 msgid "View for adding Sale Payments"
 msgstr "Verkauf Zahlung Eingeben"
+
+msgctxt "selection:sale.configuration,payment_authorize_on:"
+msgid "Manual"
+msgstr "Manuell"
+
+msgctxt "selection:sale.configuration,payment_authorize_on:"
+msgid "Sale Confirm"
+msgstr "Bei Auftragsbestätigung"
+
+msgctxt "selection:sale.configuration,payment_authorize_on:"
+msgid "Sale Process"
+msgstr "Bei Auftragsausführung"
+
+msgctxt "selection:sale.configuration,payment_capture_on:"
+msgid "Manual"
+msgstr "Manuell"
+
+msgctxt "selection:sale.configuration,payment_capture_on:"
+msgid "Sale Confirm"
+msgstr "Bei Auftragsbestätigung"
+
+msgctxt "selection:sale.configuration,payment_capture_on:"
+msgid "Sale Process"
+msgstr "Bei Auftragsausführung"
 
 msgctxt "selection:sale.payment.add_view,expiry_month:"
 msgid "01-January"

--- a/sale.py
+++ b/sale.py
@@ -135,7 +135,7 @@ class Sale:
         """
         SaleConfiguration = Pool().get('sale.configuration')
 
-        return SaleConfiguration.get_authorize_options()
+        return SaleConfiguration.payment_authorize_on.selection
 
     @classmethod
     def get_capture_options(cls):
@@ -143,7 +143,7 @@ class Sale:
         """
         SaleConfiguration = Pool().get('sale.configuration')
 
-        return SaleConfiguration.get_capture_options()
+        return SaleConfiguration.payment_capture_on.selection
 
     @staticmethod
     def default_payment_authorize_on():


### PR DESCRIPTION
Making selections translatable. …

- Migrate selection options from a function to the field.
- Use the selection property of the field to refer to the options.
- Unify quoting style in configuration to use single quotes everywhere.
- Updating the german translation.