### PR TITLE
Fix payment auth/capture on sale processing

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -376,13 +376,13 @@ class Sale:
             sale.handle_payment_on_confirm()
 
     @classmethod
-    @Workflow.transition('processing')
-    def proceed(cls, sales):
-        super(Sale, cls).proceed(sales)
-
+    def process(cls, sales):
         for sale in sales:
+            if sale.state != 'confirmed':
+                continue
             sale.handle_payment_on_process()
             sale.settle_manual_payments()
+        super(Sale, cls).proceed(sales)
 
     def _pay_using_credit_card(self, gateway, credit_card, amount):
         '''

--- a/tests/test_sale.py
+++ b/tests/test_sale.py
@@ -341,7 +341,7 @@ class TestSale(BaseTestCase):
     def _process_sale_by_completing_payments(self, sales):
         """Process sale and complete payments.
         """
-        self.Sale.proceed(sales)
+        self.Sale.process(sales)
         self.Sale.process_all_pending_payments()
 
     @with_transaction()


### PR DESCRIPTION
Sale proceed is not always called so having the
payment processing logic doesn't make sense. On the other
hand Sale.process is called multiple times so to avoid
payment getting processed multiple times check if sale
is coming from confirmed state.